### PR TITLE
Ban Phase Fix

### DIFF
--- a/game/scripts/vscripts/addon_game_mode.lua
+++ b/game/scripts/vscripts/addon_game_mode.lua
@@ -174,7 +174,7 @@ function AngelArena:InitGameMode()
 	GameRules:SetSameHeroSelectionEnabled(false)
 	GameRules:SetCustomGameAllowMusicAtGameStart( true )
 	GameRules:SetStartingGold(625)
-	GameRules:SetCustomGameBansPerTeam(2)
+	GameRules:SetCustomGameBansPerTeam(5)
 	GameRules:SetCreepSpawningEnabled( false )
 
 	-- AttributeDerivedStats


### PR DESCRIPTION
There are a lot of unbalanced heroes currently and you really need more than 2 bans to get a fun/fair game these days, and increasing the max ban amount from 2 to 5 per team would solve this issue.