### PR TITLE
Troll Warlord Fervor Boss Interaction Fix

### DIFF
--- a/game/scripts/vscripts/creeps/boss/keymaster/modifiers/modifier_keymaster_dodge_mastery.lua
+++ b/game/scripts/vscripts/creeps/boss/keymaster/modifiers/modifier_keymaster_dodge_mastery.lua
@@ -63,6 +63,10 @@ function mod:OnTakeDamage( params )
 	local damage = params.damage
 
 	if not attacker or (attacker:GetAbsOrigin() - parent:GetAbsOrigin()):Length() > self.radius then
+		if attacker:HasModifier("modifier_fervor_aa_effect") then
+			attacker:RemoveModifierByName("modifier_fervor_aa_effect")
+		end
+
 		parent:SetHealth( parent:GetHealth() + damage )
 	end
 


### PR DESCRIPTION
Currently Troll Warlord can buy Dimensional Accelerator and a Dragon Lance to have enough attack range (with a ward) to build unlimited fervor stacks without the bosses ever aggroing him. Eventually this lets him oneshot them at level 6 (since his ultimate prevents him from dying), since it only takes a minute or two to gain several thousands of damage.

This will fix that by simply removing the fervor stacks from him if he's trying to attack the bosses from outside the minimum aggro range.